### PR TITLE
Add network status property

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ class WakeOnLanAdapter extends Adapter {
         }
       });
 
-    if (this.checkPing && manifest.moziot.config.devices) {
+    if (this.checkPing && manifest.moziot.config.devices.length) {
       this.startPingChecker();
     }
   }

--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ class WakeOnLanAdapter extends Adapter {
     super(addonManager, manifest.name, manifest.name);
     addonManager.addAdapter(this);
 
-    this.checkPing = manifest.moziot.config.checkPing || true;
+    this.checkPing = manifest.moziot.config.hasOwnProperty('checkPing') ?
+      manifest.moziot.config.checkPing :
+      true;
 
     findDevices()
       .catch(console.warn)

--- a/index.js
+++ b/index.js
@@ -1,29 +1,112 @@
 'use strict';
 
-const {Adapter, Device} = require('gateway-addon');
+const {Adapter, Device, Property} = require('gateway-addon');
 const wol = require('wol');
+const findDevices = require('local-devices');
+const {promise: ping} = require('ping');
 
 class WakeOnLanAdapter extends Adapter {
   constructor(addonManager, manifest) {
     super(addonManager, manifest.name, manifest.name);
     addonManager.addAdapter(this);
 
-    for (const mac of manifest.moziot.config.devices) {
-      this.handleDeviceAdded(new WakeOnLanDevice(this, mac));
+    this.checkPing = manifest.moziot.config.checkPing || false;
+
+    findDevices().then((devices) => {
+      for (const mac of manifest.moziot.config.devices) {
+        const arpDevice = devices.find((d) => d.mac === mac.toLowerCase());
+        this.addDevice(arpDevice);
+      }
+    });
+
+    if (this.checkPing && manifest.moziot.config.devices) {
+      this.startPingChecker();
     }
+  }
+
+  addDevice(arpDevice) {
+    const deviceName = arpDevice && arpDevice.name != '?' && arpDevice.name;
+    const wolDevice = new WakeOnLanDevice(this, arpDevice.mac, deviceName);
+    if (this.devices.hasOwnProperty(wolDevice.id)) {
+      return;
+    }
+    wolDevice.checkPing(arpDevice.ip);
+    this.handleDeviceAdded(wolDevice);
+  }
+
+  handleDeviceAdded(device) {
+    if (this.checkPing && !this.interval) {
+      this.startPingChecker();
+    }
+    super.handleDeviceAdded(device);
+  }
+
+  handleDeviceRemoved(device) {
+    super.handleDeviceRemoved(device);
+    if (!Object.keys(this.devices).length) {
+      this.stopPingChecker();
+    }
+  }
+
+  startPingChecker() {
+    this.interval = setInterval(async () => {
+      const devices = await findDevices();
+      for (const device of Object.values(this.devices)) {
+        const info = devices.find((d) => d.mac === device.mac.toLowerCase());
+        if (info) {
+          device.checkPing(info.ip);
+        }
+      }
+    }, 30000);
+  }
+
+  stopPingChecker() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      delete this.interval;
+    }
+  }
+
+  unload() {
+    this.stopPingChecker();
+    return super.unload();
   }
 }
 
 class WakeOnLanDevice extends Device {
-  constructor(adapter, mac) {
+  constructor(adapter, mac, name) {
     super(adapter, `wake-on-lan-${mac}`);
 
     this.mac = mac;
-    this.name = `WoL (${mac})`;
+    this.name = name || `WoL (${mac})`;
     this.description = `WoL (${mac})`;
     this['@context'] = 'https://iot.mozilla.org/schemas';
     this['@type'] = [];
     this.addAction('wake', {label: 'Wake'});
+
+    if (adapter.checkPing) {
+      this.properties.set('on', new PingProperty(this, 'on', {
+        type: 'boolean',
+        label: 'In Network',
+      }, false));
+    }
+  }
+
+  async checkPing(ip) {
+    try {
+      const result = await ping.probe(ip);
+      this.setOn(result.alive);
+    } catch (e) {
+      this.setOn(false);
+    }
+  }
+
+  setOn(isOn) {
+    const pingProperty = this.findProperty('on');
+    if (pingProperty && pingProperty.value !== isOn) {
+      pingProperty.setCachedValue(isOn);
+      this.notifyPropertyChanged(pingProperty);
+    }
   }
 
   performAction(action) {
@@ -41,6 +124,17 @@ class WakeOnLanDevice extends Device {
         resolve();
       });
     });
+  }
+}
+
+class PingProperty extends Property {
+  constructor(device, name, description, value) {
+    description.readOnly = true;
+    super(device, name, description, value);
+  }
+
+  setValue() {
+    return Promise.reject('Read only property');
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "plugin": true,
     "exec": "{nodeLoader} {path}",
     "config": {
-      "devices": []
+      "devices": [],
+      "checkPing": true
     },
     "schema": {
       "type": "object",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
   },
   "homepage": "https://github.com/mozilla-iot/wake-on-lan-adapter#readme",
   "dependencies": {
+    "local-devices": "^2.0.0",
+    "ping": "^0.2.2",
     "wol": "^1.0.5"
   },
   "devDependencies": {
@@ -60,6 +62,12 @@
             "type": "string",
             "pattern": "^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$"
           }
+        },
+        "checkPing": {
+          "type": "boolean",
+          "label": "Ping devices",
+          "description": "Check if devices respond to ping",
+          "default": true
         }
       }
     }


### PR DESCRIPTION
This implements a "on network" read only property on devices using the `local-devices` package, which should work on linux, windows and mac. Every thirty seconds, the adapter looks for devices on the local network, maps them to the devices it's tracking and then pings the device. This means it completely relies on the MAC address and ignores the IP address except for pinging. In theory we could leave out the pinging, if we trust the ARP lookup enough, since that essentially pings every device, too, from what I understand.

It also passes along the host name from the ARP table when creating a device if the device is currently online.

Lastly, it would now in theory be possible to implement discovery, however that'd require some consideration as to what and how to write devices back to the config/database.